### PR TITLE
refactor(resolvers): 提取路由路径和名称转换逻辑到工具函数

### DIFF
--- a/src/resolvers/react.ts
+++ b/src/resolvers/react.ts
@@ -1,6 +1,6 @@
 import type { BuildTool, ResolvedOptions } from "../core/types"
 import { getGlobPattern, getWebpackContextPattern } from "../core/path"
-import { createExcludePatterns, escapeRegExp, generateExcludeCheck } from "./utils"
+import { createExcludePatterns, escapeRegExp, generateExcludeCheck, generateRoutePathTransformCode } from "./utils"
 
 /**
  * React 路由接口定义
@@ -28,31 +28,24 @@ export function generateReactViteCode(options: ResolvedOptions): string {
     const globPattern = getGlobPattern(dir, options.extensions)
     const contextVar = `__pages_${contextBlocks.length}__`
     const basePath = dir.baseRoute ? `/${dir.baseRoute}` : ""
-    // 转义路径用于正则表达式
     const escapedDir = escapeRegExp(dir.dir)
 
-    // 生成路由扫描和处理代码
+    const routePathCode = generateRoutePathTransformCode(
+      "path",
+      escapedDir,
+      basePath,
+      options.extensions,
+      "/*",
+      options.caseSensitive,
+    )
+
     contextBlocks.push(`
 const ${contextVar} = import.meta.glob('${globPattern}')
 Object.entries(${contextVar}).forEach(([path, moduleFn]) => {
-  // 忽略 __xxx 格式的文件/目录（Remix 风格）
   const pathSegments = path.split('/')
   const shouldIgnore = pathSegments.some(seg => /^__.*__$/.test(seg))
   if (shouldIgnore) return
-${excludeCheckCode ? `  ${excludeCheckCode}\n` : ""}  let routePath = path
-    .replace(/${escapedDir}/, '')
-    .replace(/^\\//, '') // 移除开头的 /
-    .replace(/\\.(tsx|jsx|ts|js)$/, '')
-    .replace(/\\/index$/, '') // 移除结尾的 /index
-    .replace(/^index$/, '') // 移除单独的 index
-    .replace(/\\[(\\.\\.\\.)?(.+?)\\]/g, (_, isCatchAll, name) =>
-      isCatchAll ? \`:\${name}/*\` : \`:\${name}\`
-    )
-    .replace(/\\$(.+)/g, ':$1') // Remix 风格: $id -> :id
-    .replace(/\\$$/, '/*') // Remix 风格: $ -> catch-all (React Router 格式)
-    ${options.caseSensitive ? "" : ".toLowerCase()"}
-
-  routePath = '${basePath}' + (routePath ? '/' + routePath : '') || '/'
+${excludeCheckCode ? `  ${excludeCheckCode}\n` : ""}  ${routePathCode}
 
   routes.push({
     path: routePath,
@@ -87,43 +80,30 @@ export function generateReactRspackCode(options: ResolvedOptions): string {
     const pattern = getWebpackContextPattern(dir, options.extensions, options.root)
     const contextVar = `__pages_${contextBlocks.length}__`
     const basePath = dir.baseRoute ? `/${dir.baseRoute}` : ""
-    // 转义路径用于正则表达式
     const escapedDir = escapeRegExp(pattern.path)
 
-    // 生成路由扫描和处理代码
-    // 注意：Rspack 的 webpackContext 使用绝对路径
-    // webpackContext 返回的是 CommonJS 模块，需要转换为 ES Module 格式
+    const routePathCode = generateRoutePathTransformCode(
+      "key",
+      escapedDir,
+      basePath,
+      options.extensions,
+      "/*",
+      options.caseSensitive,
+    )
+
     contextBlocks.push(`
 const ${contextVar} = import.meta.webpackContext('${pattern.path}', {
   recursive: ${pattern.recursive},
   regExp: /${pattern.regExp}$/
 })
 ${contextVar}.keys().forEach((key) => {
-  // 忽略 __xxx 格式的文件/目录（Remix 风格）
   const pathSegments = key.split('/')
   const shouldIgnore = pathSegments.some(seg => /^__.*__$/.test(seg))
   if (shouldIgnore) return
-${excludeCheckCode ? `  ${excludeCheckCode}\n` : ""}  let routePath = key
-    .replace(/${escapedDir}/, '')
-    .replace(/^\\.\\//, '') // 移除开头的 ./
-    .replace(/^\\//, '') // 移除开头的 /
-    .replace(/\\.(tsx|jsx|ts|js)$/, '')
-    .replace(/\\/index$/, '') // 移除结尾的 /index
-    .replace(/^index$/, '') // 移除单独的 index
-    .replace(/\\[(\\.\\.\\.)?(.+?)\\]/g, (_, isCatchAll, name) =>
-      isCatchAll ? \`:\${name}/*\` : \`:\${name}\`
-    )
-    .replace(/\\$(.+)/g, ':$1') // Remix 风格: $id -> :id
-    .replace(/\\$$/, '/*') // Remix 风格: $ -> catch-all (React Router 格式)
-    ${options.caseSensitive ? "" : ".toLowerCase()"}
+${excludeCheckCode ? `  ${excludeCheckCode}\n` : ""}  ${routePathCode}
 
-  routePath = '${basePath}' + (routePath ? '/' + routePath : '') || '/'
-
-  // webpackContext 返回 CommonJS 模块，需要转换为 ES Module 格式
-  // React.lazy 需要一个返回 Promise 的函数，Promise resolve 一个包含 default 的对象
   const loadModule = async () => {
     const module = await ${contextVar}(key)
-    // 确保返回正确的 ES Module 格式
     return { default: module.default || module }
   }
 

--- a/src/resolvers/utils.ts
+++ b/src/resolvers/utils.ts
@@ -39,6 +39,12 @@ const PLACEHOLDER_QUESTION_RE = /<<<QUESTION>>>/g
 const BACKSLASH_RE = /\\/g
 
 /**
+ * 扩展名点前缀匹配正则表达式
+ * 移到模块作用域以避免每次调用重新编译
+ */
+const EXTENSION_DOT_PREFIX_RE = /^\./
+
+/**
  * 转义正则表达式中的特殊字符
  * 包括 Windows 路径中的特殊字符（如 / 和 :）
  * @param str - 待转义的字符串
@@ -114,4 +120,73 @@ export function createExcludePatterns(exclude: string[], varName: string = "excl
  */
 export function generateExcludeCheck(pathVarName: string = "path", patternsVarName: string = "excludePatterns"): string {
   return `if (${patternsVarName}.some(pattern => pattern.test(${pathVarName}))) return`
+}
+
+/**
+ * 生成路由路径转换代码
+ * 用于将文件路径转换为路由路径
+ * @param pathVar - 路径变量名（如 'path' 或 'key'）
+ * @param escapedDir - 转义后的目录路径
+ * @param basePath - 基础路径
+ * @param extensions - 文件扩展名列表
+ * @param catchAllFormat - catch-all 格式，Vue 用 '(.*)*'，React 用 '/*'
+ * @param caseSensitive - 是否区分大小写
+ * @returns 路径转换代码字符串
+ */
+export function generateRoutePathTransformCode(
+  pathVar: string,
+  escapedDir: string,
+  basePath: string,
+  extensions: string[],
+  catchAllFormat: string,
+  caseSensitive: boolean,
+): string {
+  const extPattern = extensions.map(e => e.replace(EXTENSION_DOT_PREFIX_RE, "")).join("|")
+  const caseSuffix = caseSensitive ? "" : ".toLowerCase()"
+
+  return `let routePath = ${pathVar}
+    .replace(/${escapedDir}/, '')
+    .replace(/^\\.\\//, '')
+    .replace(/^\\//, '')
+    .replace(/\\.(${extPattern})$/, '')
+    .replace(/\\/index$/, '')
+    .replace(/^index$/, '')
+    .replace(/\\[(\\.\\.\\.)?(.+?)\\]/g, (_, isCatchAll, name) =>
+      isCatchAll ? \`:\${name}${catchAllFormat}\` : \`:\${name}\`
+    )
+    .replace(/\\$(.+)/g, ':$1')
+    .replace(/\\$$$/, '${catchAllFormat}')
+    ${caseSuffix}
+
+  routePath = '${basePath}' + (routePath ? '/' + routePath : '') || '/'`
+}
+
+/**
+ * 生成路由名称转换代码
+ * 用于将文件路径转换为路由名称
+ * @param pathVar - 路径变量名（如 'path' 或 'key'）
+ * @param escapedDir - 转义后的目录路径
+ * @param extensions - 文件扩展名列表
+ * @param routeNameSeparator - 路由名称分隔符
+ * @returns 路由名称转换代码字符串
+ */
+export function generateRouteNameTransformCode(
+  pathVar: string,
+  escapedDir: string,
+  extensions: string[],
+  routeNameSeparator: string,
+): string {
+  const extPattern = extensions.map(e => e.replace(EXTENSION_DOT_PREFIX_RE, "")).join("|")
+
+  return `const name = ${pathVar}
+    .replace(/${escapedDir}/, '')
+    .replace(/^\\.\\//, '')
+    .replace(/^\\//, '')
+    .replace(/\\.(${extPattern})$/, '')
+    .replace(/\\/index$/, '')
+    .replace(/^index$/, '')
+    .replace(/\\//g, '${routeNameSeparator}')
+    .replace(/\\[(\\.\\.\\.)?(.+?)\\]/g, '$2')
+    .replace(/\\$(.+)/g, '$1')
+    .replace(/^${routeNameSeparator}/, '') || 'index'`
 }

--- a/src/resolvers/vue.ts
+++ b/src/resolvers/vue.ts
@@ -1,6 +1,6 @@
 import type { BuildTool, ResolvedOptions } from "../core/types"
 import { getGlobPattern, getWebpackContextPattern } from "../core/path"
-import { createExcludePatterns, escapeRegExp, generateExcludeCheck } from "./utils"
+import { createExcludePatterns, escapeRegExp, generateExcludeCheck, generateRouteNameTransformCode, generateRoutePathTransformCode } from "./utils"
 
 /**
  * Vue 路由接口定义
@@ -29,42 +29,33 @@ export function generateVueViteCode(options: ResolvedOptions): string {
     const globPattern = getGlobPattern(dir, options.extensions)
     const contextVar = `__pages_${contextBlocks.length}__`
     const basePath = dir.baseRoute ? `/${dir.baseRoute}` : ""
-    // 转义路径用于正则表达式
     const escapedDir = escapeRegExp(dir.dir)
 
-    // 生成路由扫描和处理代码
+    const routePathCode = generateRoutePathTransformCode(
+      "path",
+      escapedDir,
+      basePath,
+      options.extensions,
+      "(.*)*",
+      options.caseSensitive,
+    )
+
+    const routeNameCode = generateRouteNameTransformCode(
+      "path",
+      escapedDir,
+      options.extensions,
+      options.routeNameSeparator,
+    )
+
     contextBlocks.push(`
 const ${contextVar} = import.meta.glob('${globPattern}')
 Object.entries(${contextVar}).forEach(([path, module]) => {
-  // 忽略 __xxx 格式的文件/目录（Remix 风格）
   const pathSegments = path.split('/')
   const shouldIgnore = pathSegments.some(seg => /^__.*__$/.test(seg))
   if (shouldIgnore) return
-${excludeCheckCode ? `  ${excludeCheckCode}\n` : ""}  let routePath = path
-    .replace(/${escapedDir}/, '')
-    .replace(/^\\//, '') // 移除开头的 /
-    .replace(/\\.(vue|ts|js)$/, '')
-    .replace(/\\/index$/, '') // 移除结尾的 /index
-    .replace(/^index$/, '') // 移除单独的 index
-    .replace(/\\[(\\.\\.\\.)?(.+?)\\]/g, (_, isCatchAll, name) =>
-      isCatchAll ? \`:\${name}(.*)*\` : \`:\${name}\`
-    )
-    .replace(/\\$(.+)/g, ':$1') // Remix 风格: $id -> :id
-    .replace(/\\$$/, '(.*)*') // Remix 风格: $ -> catch-all
-    ${options.caseSensitive ? "" : ".toLowerCase()"}
+${excludeCheckCode ? `  ${excludeCheckCode}\n` : ""}  ${routePathCode}
 
-  routePath = '${basePath}' + (routePath ? '/' + routePath : '') || '/'
-
-  const name = path
-    .replace(/${escapedDir}/, '')
-    .replace(/^\\//, '') // 移除开头的 /
-    .replace(/\\.(vue|ts|js)$/, '')
-    .replace(/\\/index$/, '') // 移除结尾的 /index
-    .replace(/^index$/, '') // 移除单独的 index
-    .replace(/\\//g, '${options.routeNameSeparator}')
-    .replace(/\\[(\\.\\.\\.)?(.+?)\\]/g, '$2') // Next.js 风格
-    .replace(/\\$(.+)/g, '$1') // Remix 风格
-    .replace(/^${options.routeNameSeparator}/, '') || 'index'
+  ${routeNameCode}
 
   routes.push({
     path: routePath,
@@ -98,48 +89,36 @@ export function generateVueRspackCode(options: ResolvedOptions): string {
     const pattern = getWebpackContextPattern(dir, options.extensions, options.root)
     const contextVar = `__pages_${contextBlocks.length}__`
     const basePath = dir.baseRoute ? `/${dir.baseRoute}` : ""
-    // 转义路径用于正则表达式
     const escapedDir = escapeRegExp(pattern.path)
 
-    // 生成路由扫描和处理代码
-    // 注意：Rspack 的 webpackContext 使用绝对路径
+    const routePathCode = generateRoutePathTransformCode(
+      "key",
+      escapedDir,
+      basePath,
+      options.extensions,
+      "(.*)*",
+      options.caseSensitive,
+    )
+
+    const routeNameCode = generateRouteNameTransformCode(
+      "key",
+      escapedDir,
+      options.extensions,
+      options.routeNameSeparator,
+    )
+
     contextBlocks.push(`
 const ${contextVar} = import.meta.webpackContext('${pattern.path}', {
   recursive: ${pattern.recursive},
   regExp: /${pattern.regExp}$/
 })
 ${contextVar}.keys().forEach((key) => {
-  // 忽略 __xxx 格式的文件/目录（Remix 风格）
   const pathSegments = key.split('/')
   const shouldIgnore = pathSegments.some(seg => /^__.*__$/.test(seg))
   if (shouldIgnore) return
-${excludeCheckCode ? `  ${excludeCheckCode}\n` : ""}  let routePath = key
-    .replace(/${escapedDir}/, '')
-    .replace(/^\\.\\//, '') // 移除开头的 ./
-    .replace(/^\\//, '') // 移除开头的 /
-    .replace(/\\.(vue|ts|js)$/, '')
-    .replace(/\\/index$/, '') // 移除结尾的 /index
-    .replace(/^index$/, '') // 移除单独的 index
-    .replace(/\\[(\\.\\.\\.)?(.+?)\\]/g, (_, isCatchAll, name) =>
-      isCatchAll ? \`:\${name}(.*)*\` : \`:\${name}\`
-    )
-    .replace(/\\$(.+)/g, ':$1') // Remix 风格: $id -> :id
-    .replace(/\\$$/, '(.*)*') // Remix 风格: $ -> catch-all
-    ${options.caseSensitive ? "" : ".toLowerCase()"}
+${excludeCheckCode ? `  ${excludeCheckCode}\n` : ""}  ${routePathCode}
 
-  routePath = '${basePath}' + (routePath ? '/' + routePath : '') || '/'
-
-  const name = key
-    .replace(/${escapedDir}/, '')
-    .replace(/^\\.\\//, '') // 移除开头的 ./
-    .replace(/^\\//, '') // 移除开头的 /
-    .replace(/\\.(vue|ts|js)$/, '')
-    .replace(/\\/index$/, '') // 移除结尾的 /index
-    .replace(/^index$/, '') // 移除单独的 index
-    .replace(/\\//g, '${options.routeNameSeparator}')
-    .replace(/\\[(\\.\\.\\.)?(.+?)\\]/g, '$2') // Next.js 风格
-    .replace(/\\$(.+)/g, '$1') // Remix 风格
-    .replace(/^${options.routeNameSeparator}/, '') || 'index'
+  ${routeNameCode}
 
   routes.push({
     path: routePath,


### PR DESCRIPTION
将 React 和 Vue 解析器中的重复路由路径和名称转换逻辑提取到 utils.ts 中的通用工具函数 添加 EXTENSION_DOT_PREFIX_RE 正则表达式常量避免重复编译

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化了路由路径和路由名称的代码生成逻辑，提高了代码可维护性。

**备注：** 本次更新为内部代码优化，不涉及功能变更或用户体验影响。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->