### PR TITLE
修复 Rspack load hook 误处理普通 JSON 模块

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,10 @@ const VIRTUAL_MODULE_IDS = {
   ],
 }
 
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+
+const createExactIdFilter = (ids: string[]): RegExp => new RegExp(`^(?:${ids.map(escapeRegExp).join("|")})$`)
+
 /**
  * unplugin 工厂函数
  * 创建约定式路由插件的核心实现
@@ -36,6 +40,7 @@ export const unpluginFactory: UnpluginFactory<UserOptions> = (userOptions, { fra
 
   // 获取当前 resolver 对应的虚拟模块 ID 列表
   const virtualIds = VIRTUAL_MODULE_IDS[options.resolver]
+  const virtualIdFilter = createExactIdFilter(virtualIds)
 
   return {
     name: "unplugin-convention-routes",
@@ -46,11 +51,16 @@ export const unpluginFactory: UnpluginFactory<UserOptions> = (userOptions, { fra
      * @param id - 模块 ID
      * @returns 解析后的模块 ID 或 null
      */
-    resolveId(id) {
-      if (virtualIds.includes(id)) {
-        return virtualIds[0]
-      }
-      return null
+    resolveId: {
+      filter: {
+        id: virtualIdFilter,
+      },
+      handler(id) {
+        if (virtualIds.includes(id)) {
+          return virtualIds[0]
+        }
+        return null
+      },
     },
 
     /**
@@ -59,11 +69,16 @@ export const unpluginFactory: UnpluginFactory<UserOptions> = (userOptions, { fra
      * @param id - 模块 ID
      * @returns 生成的代码或 null
      */
-    load(id) {
-      if (id === virtualIds[0]) {
-        return generateRoutes(options, buildTool)
-      }
-      return null
+    load: {
+      filter: {
+        id: virtualIdFilter,
+      },
+      handler(id) {
+        if (id === virtualIds[0]) {
+          return generateRoutes(options, buildTool)
+        }
+        return null
+      },
     },
   }
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { unpluginFactory } from '../src'
+
+describe('unpluginFactory', () => {
+  it('only applies the load hook to virtual modules', () => {
+    const plugin = unpluginFactory(
+      {
+        resolver: 'react',
+      },
+      {
+        framework: 'rspack',
+      },
+    ) as any
+
+    expect(plugin.load.filter.id).toBeInstanceOf(RegExp)
+    expect(plugin.load.filter.id.test('virtual:unplugin-convention-routes/react')).toBe(true)
+    expect(plugin.load.filter.id.test('~react-pages')).toBe(true)
+    expect(plugin.load.filter.id.test('/node_modules/pkg/i18n/en.json')).toBe(false)
+  })
+
+  it('normalizes route aliases to the canonical virtual module id', async () => {
+    const plugin = unpluginFactory(
+      {
+        resolver: 'vue',
+      },
+      {
+        framework: 'rspack',
+      },
+    ) as any
+
+    expect(plugin.resolveId.handler('~pages')).toBe(
+      'virtual:unplugin-convention-routes/vue',
+    )
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["ESNext", "DOM"],
     "module": "ESNext",
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "resolveJsonModule": true,
     "strict": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## 变更内容

- 为 resolveId 和 load hook 增加精确的虚拟模块 ID 过滤条件。
- 避免 Rspack/Webpack 的 load loader 作用到普通依赖资源，例如 @ycloud/components 中的 i18n JSON 文件。
- 新增测试覆盖虚拟路由模块命中、依赖 JSON 路径不命中的场景。
- 增加 ignoreDeprecations: "6.0"，保证当前 TypeScript 6 下 type-check 可以正常运行。

## 问题背景

在 Rspack 适配下，只要插件定义了 load hook，unplugin 会注入一条 loader 规则。如果该 hook 没有过滤条件，loader 可能会作用到不相关的普通模块。

在 Rsbuild/Rspack 项目中引入 @ycloud/components 时，@ycloud/components/dist/i18n/en.json 等 JSON 文件会被 unplugin/dist/rspack/loaders/load.mjs 处理，并继续按 JavaScript 解析，最终导致构建失败。

## 验证

- ./node_modules/.bin/vitest run
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/eslint .
- ./node_modules/.bin/tsdown


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Refactor**
  * 改进了虚拟模块 ID 的匹配机制，提升了识别精度。

* **Tests**
  * 新增测试用例，覆盖虚拟模块 ID 的过滤和规范化行为。

* **Chores**
  * 更新 TypeScript 编译器配置。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/liujiayii/unplugin-convention-routes/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->