### PR TITLE
build: 更新pnpm版本并添加允许构建的依赖包

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "unplugin-convention-routes",
   "type": "module",
   "version": "0.1.0",
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.3.0",
   "description": "File system base router plugin for unplugin",
   "author": "liujiayii@foxmail.com",
   "license": "MIT",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,7 @@ trustPolicy: no-downgrade
 
 packages:
   - examples/*
+
+allowBuilds:
+  core-js: true
+  esbuild: true


### PR DESCRIPTION
- 将packageManager中的pnpm版本从10.33.4升级到11.3.0
- 在pnpm-workspace.yaml中添加core-js和esbuild的允许构建配置